### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ This repository contains artifacts from creating a computer from scratch.
 
  - Create gates with resistors, diodes and buttons
  - Create gates with HDL language
- - Build assember
+ - Build assembler
  - Build VM language
  - Build lanugage that compiles to VM


### PR DESCRIPTION
There was typo in assembler word.